### PR TITLE
fix: expand carport and pole truss detail pages (closes #7)

### DIFF
--- a/src/app/boxed-eave-style-metal-carport/page.tsx
+++ b/src/app/boxed-eave-style-metal-carport/page.tsx
@@ -4,34 +4,95 @@ import { Layout } from "@/components/layout";
 import { COMPANY } from "@/lib/constants";
 
 export const metadata: Metadata = {
-  title: "Kings Roofing, inc. | Boxed Eave Style Metal Carport",
-  description: "Boxed-eave metal carports with A-frame roof design to match your home. Quality metal carports in Western NC.",
+  title: "Boxed Eave Style Metal Carport | Kings Roofing, inc.",
+  description: "Boxed eave style metal carports with A-frame roof in Western NC. Matches home roof styles. Free quotes from Kings Roofing.",
 };
 
-export default function BoxedEaveCarportPage() {
+const USE_CASES = [
+  {
+    "title": "Home-Matching Aesthetics",
+    "desc": "The A-frame profile closely mirrors a standard gable roof \u2014 ideal when curb appeal matters."
+  },
+  {
+    "title": "Dual-Car Coverage",
+    "desc": "Available in widths up to 26' for side-by-side vehicle protection."
+  },
+  {
+    "title": "Enclosed End Storage",
+    "desc": "Easily add sides and ends to convert to a fully enclosed garage."
+  },
+  {
+    "title": "Carports + Storage Combos",
+    "desc": "Pair a carport bay with an attached storage room in one continuous structure."
+  }
+];
+
+const SPECS = [
+  "Available in 12', 18', 20', 22', 24', and 26' widths",
+  "Boxed eave trim on all sides for a finished appearance",
+  "29-gauge steel panels with 40-year rust-through warranty",
+  "7', 8', 9', and 10' leg heights",
+  "18 standard color options",
+  "Certifiable to local wind and snow load codes"
+];
+
+export default function Page() {
   return (
     <Layout>
       {/* Hero */}
       <section className="bg-gradient-to-br from-gray-900 to-gray-800 text-white py-20">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl">
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">
-              Boxed Eave Style Metal Carport
-            </h1>
-            <h2 className="text-2xl text-orange-400 mb-6">
-              Boxed Eave Style
-            </h2>
-            <p className="text-xl text-gray-300">
-              Boxed-eave metal carports are built with an A-frame roof. Many homeowners choose this option to have a metal carport that will match the roof style of their home.
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">Boxed Eave Style Metal Carport</h1>
+            <p className="text-xl text-gray-300 mb-8">
+              The boxed eave carport features an A-frame design with horizontal panels and enclosed eave trim, giving it a cleaner, more finished look that complements most homes. A popular upgrade from the regular style.
             </p>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <Link href="/contact" className="inline-flex items-center justify-center bg-orange-500 hover:bg-orange-600 text-white px-8 py-4 rounded-lg font-semibold">
+                Get a Free Quote
+              </Link>
+              <a href={`tel:${COMPANY.phone}`} className="inline-flex items-center justify-center bg-white/10 hover:bg-white/20 text-white px-8 py-4 rounded-lg font-semibold border border-white/20">
+                Call {COMPANY.phone}
+              </a>
+            </div>
           </div>
+        </div>
+      </section>
+
+      {/* Use Cases */}
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold text-gray-900 mb-10">Common Uses</h2>
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl">
+            {USE_CASES.map((item) => (
+              <div key={item.title} className="bg-gray-50 rounded-xl p-6 border border-gray-100">
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{item.title}</h3>
+                <p className="text-gray-600">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Specs */}
+      <section className="py-20 bg-gray-900 text-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold mb-8">Specs & Features</h2>
+          <ul className="space-y-4 max-w-2xl">
+            {SPECS.map((spec) => (
+              <li key={spec} className="flex items-start gap-3">
+                <span className="text-orange-400 font-bold mt-1">✓</span>
+                <span className="text-gray-300">{spec}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       </section>
 
       {/* Contact CTA */}
       <section className="py-20 bg-orange-500">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold text-white mb-4">Contact Us Today!</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">Get Your Free Quote</h2>
           <div className="space-y-4 mb-8">
             <p className="text-2xl text-white font-semibold">
               <a href={`tel:${COMPANY.phone}`} className="hover:underline">{COMPANY.phone}</a>
@@ -40,10 +101,7 @@ export default function BoxedEaveCarportPage() {
               <a href={`mailto:${COMPANY.email}`} className="hover:underline">{COMPANY.email}</a>
             </p>
           </div>
-          <Link
-            href="/contact"
-            className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg"
-          >
+          <Link href="/contact" className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg">
             Free Quotes…
           </Link>
         </div>

--- a/src/app/pole-truss-enclosed-kits/page.tsx
+++ b/src/app/pole-truss-enclosed-kits/page.tsx
@@ -4,42 +4,95 @@ import { Layout } from "@/components/layout";
 import { COMPANY } from "@/lib/constants";
 
 export const metadata: Metadata = {
-  title: "Pole Truss Enclosed Kits | Kings Roofing, inc.",
-  description: "Pole Barn Enclosed Kit - closed roof and all sides with doors and windows. 18 metal colors, 40 year guarantee. Western NC.",
+  title: "Pole Truss Enclosed Kit | Kings Roofing, inc.",
+  description: "Pole truss enclosed kits — fully enclosed metal buildings with doors and windows in Western NC. 40-year warranty. Kings Roofing.",
 };
 
-export default function PoleTrussEnclosedPage() {
+const USE_CASES = [
+  {
+    "title": "Workshops & Garages",
+    "desc": "Full enclosure keeps tools, vehicles, and projects protected year-round."
+  },
+  {
+    "title": "Agricultural Storage",
+    "desc": "Hay barns, grain storage, and equipment buildings at a fraction of conventional construction costs."
+  },
+  {
+    "title": "Retail & Small Business",
+    "desc": "Cost-effective building solution for pop-up retail, storage businesses, or light manufacturing."
+  },
+  {
+    "title": "Hobby & Craft Space",
+    "desc": "Climate-controlled with your choice of doors and windows for a dedicated studio or shop."
+  }
+];
+
+const SPECS = [
+  "Closed from roof and all four sides",
+  "Doors and windows: your choice of location and size",
+  "29-gauge 40-year steel roofing and wall panels",
+  "18 in-stock colors for roof and walls",
+  "Multiple width and length configurations",
+  "Meets WNC wind, snow, and building code requirements"
+];
+
+export default function Page() {
   return (
     <Layout>
       {/* Hero */}
       <section className="bg-gradient-to-br from-gray-900 to-gray-800 text-white py-20">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl">
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">
-              Pole Truss Enclosed Kits
-            </h1>
-            <h2 className="text-2xl text-orange-400 mb-6">
-              Enclosed Style
-            </h2>
-            <p className="text-xl text-gray-300 mb-6">
-              Pole Barn Enclosed Kit – A Pole Barn Enclosed, is closed from the roof and all sides with an adding of doors and windows of your choice. Select your color from 18 different in stock 29 gauge metals. 40 year guarantee! We also sell carport kits.
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">Pole Truss Enclosed Kit</h1>
+            <p className="text-xl text-gray-300 mb-8">
+              A pole truss enclosed kit is a fully enclosed metal building — roof, all four walls, doors, and windows of your choice. Built from the same 29-gauge steel as our open kits, with a 40-year guarantee. The most cost-effective enclosed building on the market.
             </p>
-            <a 
-              href="https://www.facebook.com/kingsroofinginc"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center text-orange-400 hover:underline font-semibold"
-            >
-              Check Us Out On Facebook!
-            </a>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <Link href="/contact" className="inline-flex items-center justify-center bg-orange-500 hover:bg-orange-600 text-white px-8 py-4 rounded-lg font-semibold">
+                Get a Free Quote
+              </Link>
+              <a href={`tel:${COMPANY.phone}`} className="inline-flex items-center justify-center bg-white/10 hover:bg-white/20 text-white px-8 py-4 rounded-lg font-semibold border border-white/20">
+                Call {COMPANY.phone}
+              </a>
+            </div>
           </div>
+        </div>
+      </section>
+
+      {/* Use Cases */}
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold text-gray-900 mb-10">Common Uses</h2>
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl">
+            {USE_CASES.map((item) => (
+              <div key={item.title} className="bg-gray-50 rounded-xl p-6 border border-gray-100">
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{item.title}</h3>
+                <p className="text-gray-600">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Specs */}
+      <section className="py-20 bg-gray-900 text-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold mb-8">Specs & Features</h2>
+          <ul className="space-y-4 max-w-2xl">
+            {SPECS.map((spec) => (
+              <li key={spec} className="flex items-start gap-3">
+                <span className="text-orange-400 font-bold mt-1">✓</span>
+                <span className="text-gray-300">{spec}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       </section>
 
       {/* Contact CTA */}
       <section className="py-20 bg-orange-500">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold text-white mb-4">Contact Us Today!</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">Get Your Free Quote</h2>
           <div className="space-y-4 mb-8">
             <p className="text-2xl text-white font-semibold">
               <a href={`tel:${COMPANY.phone}`} className="hover:underline">{COMPANY.phone}</a>
@@ -48,10 +101,7 @@ export default function PoleTrussEnclosedPage() {
               <a href={`mailto:${COMPANY.email}`} className="hover:underline">{COMPANY.email}</a>
             </p>
           </div>
-          <Link
-            href="/contact"
-            className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg"
-          >
+          <Link href="/contact" className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg">
             Free Quotes…
           </Link>
         </div>

--- a/src/app/pole-truss-stand-roof-kit/page.tsx
+++ b/src/app/pole-truss-stand-roof-kit/page.tsx
@@ -4,42 +4,95 @@ import { Layout } from "@/components/layout";
 import { COMPANY } from "@/lib/constants";
 
 export const metadata: Metadata = {
-  title: "Pole Truss Stand Roof Kits | Kings Roofing, inc.",
-  description: "Pole Barn Stand Roof Kit - just the roof closed with open sides. 18 metal colors, 40 year guarantee. Western NC.",
+  title: "Pole Truss Stand Roof Kit | Kings Roofing, inc.",
+  description: "Pole truss stand roof kits for open-air shelters and agricultural structures in Western NC. Durable steel construction from Kings Roofing.",
 };
 
-export default function PoleTrussStandRoofPage() {
+const USE_CASES = [
+  {
+    "title": "Open-Air Pavilions",
+    "desc": "Great for outdoor seating, event coverage, or farm market shelters."
+  },
+  {
+    "title": "Equipment Staging",
+    "desc": "Keep machinery, baled hay, or lumber dry without full enclosure costs."
+  },
+  {
+    "title": "Livestock Shelter",
+    "desc": "Open sides allow airflow while the roof keeps animals dry."
+  },
+  {
+    "title": "Loading Dock Covers",
+    "desc": "Covers loading areas without interfering with forklift access."
+  }
+];
+
+const SPECS = [
+  "29-gauge steel roof panels \u2014 40-year rust-through warranty",
+  "Open sides for maximum airflow and access",
+  "Multiple width and length configurations available",
+  "Custom heights to suit your application",
+  "18 color options",
+  "Engineered for WNC wind and snow loads"
+];
+
+export default function Page() {
   return (
     <Layout>
       {/* Hero */}
       <section className="bg-gradient-to-br from-gray-900 to-gray-800 text-white py-20">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl">
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">
-              Pole Truss Stand Roof Kit
-            </h1>
-            <h2 className="text-2xl text-orange-400 mb-6">
-              Stand Roof Style
-            </h2>
-            <p className="text-xl text-gray-300 mb-6">
-              Pole Barn Stand Roof Kit – A Pole Barn Stand Roof, is just the roof closed with the open sides. Select your color from 18 different in stock 29 gauge metals. 40 year guarantee! We also sell carport kits.
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">Pole Truss Stand Roof Kit</h1>
+            <p className="text-xl text-gray-300 mb-8">
+              Our pole truss stand roof kit delivers an open-sided, covered shelter — perfect for picnic pavilions, equipment staging areas, and livestock shelters. Simple steel construction with lasting weather protection.
             </p>
-            <a 
-              href="https://www.facebook.com/kingsroofinginc"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center text-orange-400 hover:underline font-semibold"
-            >
-              Check Us Out On Facebook!
-            </a>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <Link href="/contact" className="inline-flex items-center justify-center bg-orange-500 hover:bg-orange-600 text-white px-8 py-4 rounded-lg font-semibold">
+                Get a Free Quote
+              </Link>
+              <a href={`tel:${COMPANY.phone}`} className="inline-flex items-center justify-center bg-white/10 hover:bg-white/20 text-white px-8 py-4 rounded-lg font-semibold border border-white/20">
+                Call {COMPANY.phone}
+              </a>
+            </div>
           </div>
+        </div>
+      </section>
+
+      {/* Use Cases */}
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold text-gray-900 mb-10">Common Uses</h2>
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl">
+            {USE_CASES.map((item) => (
+              <div key={item.title} className="bg-gray-50 rounded-xl p-6 border border-gray-100">
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{item.title}</h3>
+                <p className="text-gray-600">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Specs */}
+      <section className="py-20 bg-gray-900 text-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold mb-8">Specs & Features</h2>
+          <ul className="space-y-4 max-w-2xl">
+            {SPECS.map((spec) => (
+              <li key={spec} className="flex items-start gap-3">
+                <span className="text-orange-400 font-bold mt-1">✓</span>
+                <span className="text-gray-300">{spec}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       </section>
 
       {/* Contact CTA */}
       <section className="py-20 bg-orange-500">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold text-white mb-4">Contact Us Today!</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">Get Your Free Quote</h2>
           <div className="space-y-4 mb-8">
             <p className="text-2xl text-white font-semibold">
               <a href={`tel:${COMPANY.phone}`} className="hover:underline">{COMPANY.phone}</a>
@@ -48,10 +101,7 @@ export default function PoleTrussStandRoofPage() {
               <a href={`mailto:${COMPANY.email}`} className="hover:underline">{COMPANY.email}</a>
             </p>
           </div>
-          <Link
-            href="/contact"
-            className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg"
-          >
+          <Link href="/contact" className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg">
             Free Quotes…
           </Link>
         </div>

--- a/src/app/regular-style-metal-carports/page.tsx
+++ b/src/app/regular-style-metal-carports/page.tsx
@@ -5,8 +5,25 @@ import { COMPANY } from "@/lib/constants";
 
 export const metadata: Metadata = {
   title: "Regular Style Metal Carport | Kings Roofing, inc.",
-  description: "Regular style metal carports for car shelters, boat storage, RV carports, and more. Affordable metal carport solutions in Western NC.",
+  description: "Regular style metal carports for car shelters, boat storage, RV carports, and more. Affordable metal carport solutions in Western NC. Free quotes.",
 };
+
+const USE_CASES = [
+  { title: "Vehicle Protection", desc: "Single and double carports to protect your car, truck, or SUV from rain, hail, and UV damage." },
+  { title: "Boat & RV Storage", desc: "Wide-span options available for boats, trailers, and full-size RVs year-round." },
+  { title: "Farm Equipment", desc: "Cover tractors, ATVs, and equipment from the elements without the cost of a full building." },
+  { title: "Combo Units", desc: "Pair with enclosed storage bays for a versatile workspace or workshop." },
+];
+
+const SPECS = [
+  "Available in 12', 18', 20', 22', 24', and 26' widths",
+  "Standard lengths from 21' to 51' (custom available)",
+  "7', 8', 9', and 10' leg heights",
+  "29-gauge steel roofing panels — 40-year rust-through warranty",
+  "Choice of 18 standard colors",
+  "A-frame horizontal roof panels",
+  "Certified to meet local wind and snow load requirements",
+];
 
 export default function RegularStyleCarportsPage() {
   return (
@@ -15,23 +32,69 @@ export default function RegularStyleCarportsPage() {
       <section className="bg-gradient-to-br from-gray-900 to-gray-800 text-white py-20">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl">
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">
-              Regular Style Metal Carports
-            </h1>
-            <h2 className="text-2xl text-orange-400 mb-6">
-              Regular Style
-            </h2>
-            <p className="text-xl text-gray-300">
-              Regular Style Carports are often used for inexpensive car shelters, single and double metal carports, boat storage shelters, RV carports, and for value-priced combo carports or carports with storage buildings.
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">Regular Style Metal Carports</h1>
+            <p className="text-xl text-gray-300 mb-8">
+              The most affordable and popular carport style — sturdy A-frame construction with horizontal roof panels. Perfect for vehicles, boats, RVs, and equipment storage in Western NC.
             </p>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <Link href="/contact" className="inline-flex items-center justify-center bg-orange-500 hover:bg-orange-600 text-white px-8 py-4 rounded-lg font-semibold">
+                Get a Free Quote
+              </Link>
+              <a href={`tel:${COMPANY.phone}`} className="inline-flex items-center justify-center bg-white/10 hover:bg-white/20 text-white px-8 py-4 rounded-lg font-semibold border border-white/20">
+                Call {COMPANY.phone}
+              </a>
+            </div>
           </div>
+        </div>
+      </section>
+
+      {/* Use Cases */}
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold text-gray-900 mb-10">What Can a Regular Style Carport Do For You?</h2>
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl">
+            {USE_CASES.map((item) => (
+              <div key={item.title} className="bg-gray-50 rounded-xl p-6 border border-gray-100">
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{item.title}</h3>
+                <p className="text-gray-600">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Specs */}
+      <section className="py-20 bg-gray-900 text-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold mb-8">Specs & Options</h2>
+          <ul className="space-y-4 max-w-2xl">
+            {SPECS.map((spec) => (
+              <li key={spec} className="flex items-start gap-3">
+                <span className="text-orange-400 font-bold mt-1">✓</span>
+                <span className="text-gray-300">{spec}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* Why Kings Roofing */}
+      <section className="py-20 bg-gray-50">
+        <div className="container mx-auto px-4 max-w-3xl">
+          <h2 className="text-3xl font-bold text-gray-900 mb-6">Why Choose Kings Roofing?</h2>
+          <p className="text-gray-600 text-lg mb-4">
+            We've been installing metal carports across Western North Carolina for over a decade. Every structure is professionally installed by our local crew — no sub-contractors, no surprises.
+          </p>
+          <p className="text-gray-600 text-lg">
+            All our metal carports are backed by manufacturer warranties and installed to meet North Carolina's wind and snow load codes. Call us for a free, no-pressure quote.
+          </p>
         </div>
       </section>
 
       {/* Contact CTA */}
       <section className="py-20 bg-orange-500">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold text-white mb-4">Contact Us Today!</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">Ready to Get Started?</h2>
           <div className="space-y-4 mb-8">
             <p className="text-2xl text-white font-semibold">
               <a href={`tel:${COMPANY.phone}`} className="hover:underline">{COMPANY.phone}</a>
@@ -40,10 +103,7 @@ export default function RegularStyleCarportsPage() {
               <a href={`mailto:${COMPANY.email}`} className="hover:underline">{COMPANY.email}</a>
             </p>
           </div>
-          <Link
-            href="/contact"
-            className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg"
-          >
+          <Link href="/contact" className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg">
             Free Quotes…
           </Link>
         </div>

--- a/src/app/vertical-roof-style-metal-carport/page.tsx
+++ b/src/app/vertical-roof-style-metal-carport/page.tsx
@@ -4,34 +4,95 @@ import { Layout } from "@/components/layout";
 import { COMPANY } from "@/lib/constants";
 
 export const metadata: Metadata = {
-  title: "Kings Roofing, inc. | Vertical Roof Style Metal Carport​",
-  description: "Vertical roof style metal carport - the strongest roof style available. Quality metal carports in Western NC.",
+  title: "Vertical Roof Style Metal Carport | Kings Roofing, inc.",
+  description: "Vertical roof metal carports — the strongest style available. Snow and debris shed easily. Western NC installation by Kings Roofing.",
 };
 
-export default function VerticalRoofCarportPage() {
+const USE_CASES = [
+  {
+    "title": "Heavy Snow & Rain Areas",
+    "desc": "Vertical panels shed accumulation before it adds load \u2014 critical in mountain counties."
+  },
+  {
+    "title": "Long-Term Durability",
+    "desc": "Tighter panel overlaps and hat-channel framing make this the longest-lasting configuration."
+  },
+  {
+    "title": "Larger Spans",
+    "desc": "Handles wider and longer footprints with greater rigidity than other styles."
+  },
+  {
+    "title": "Commercial & Agricultural",
+    "desc": "Trusted for farm equipment, commercial fleets, and industrial storage."
+  }
+];
+
+const SPECS = [
+  "Available in 12' through 40'+ widths (custom spans available)",
+  "Vertical 29-gauge panels from ridge to eave \u2014 no horizontal seams",
+  "Hat-channel framing adds rigidity and reduces panel oil-canning",
+  "40-year rust-through warranty on panels",
+  "Highest wind and snow load ratings of any carport style",
+  "7' to 16' leg heights available"
+];
+
+export default function Page() {
   return (
     <Layout>
       {/* Hero */}
       <section className="bg-gradient-to-br from-gray-900 to-gray-800 text-white py-20">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl">
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">
-              Vertical Roof Style Metal Carport
-            </h1>
-            <h2 className="text-2xl text-orange-400 mb-6">
-              Vertical Roof Style
-            </h2>
-            <p className="text-xl text-gray-300">
-              The vertical roof style metal carport is the strongest roof style available. The roofing panels on this metal carport are laid in a vertical orientation starting from the peak and ending at the eaves/sides.
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">Vertical Roof Style Metal Carport</h1>
+            <p className="text-xl text-gray-300 mb-8">
+              The vertical roof is the premium option — roofing panels run ridge to eave so water, snow, and debris shed immediately. The most structurally sound carport style and the best choice for WNC's weather.
             </p>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <Link href="/contact" className="inline-flex items-center justify-center bg-orange-500 hover:bg-orange-600 text-white px-8 py-4 rounded-lg font-semibold">
+                Get a Free Quote
+              </Link>
+              <a href={`tel:${COMPANY.phone}`} className="inline-flex items-center justify-center bg-white/10 hover:bg-white/20 text-white px-8 py-4 rounded-lg font-semibold border border-white/20">
+                Call {COMPANY.phone}
+              </a>
+            </div>
           </div>
+        </div>
+      </section>
+
+      {/* Use Cases */}
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold text-gray-900 mb-10">Common Uses</h2>
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl">
+            {USE_CASES.map((item) => (
+              <div key={item.title} className="bg-gray-50 rounded-xl p-6 border border-gray-100">
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{item.title}</h3>
+                <p className="text-gray-600">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Specs */}
+      <section className="py-20 bg-gray-900 text-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold mb-8">Specs & Features</h2>
+          <ul className="space-y-4 max-w-2xl">
+            {SPECS.map((spec) => (
+              <li key={spec} className="flex items-start gap-3">
+                <span className="text-orange-400 font-bold mt-1">✓</span>
+                <span className="text-gray-300">{spec}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       </section>
 
       {/* Contact CTA */}
       <section className="py-20 bg-orange-500">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold text-white mb-4">Contact Us Today!</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">Get Your Free Quote</h2>
           <div className="space-y-4 mb-8">
             <p className="text-2xl text-white font-semibold">
               <a href={`tel:${COMPANY.phone}`} className="hover:underline">{COMPANY.phone}</a>
@@ -40,10 +101,7 @@ export default function VerticalRoofCarportPage() {
               <a href={`mailto:${COMPANY.email}`} className="hover:underline">{COMPANY.email}</a>
             </p>
           </div>
-          <Link
-            href="/contact"
-            className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg"
-          >
+          <Link href="/contact" className="inline-flex items-center justify-center bg-white hover:bg-gray-100 text-gray-900 px-8 py-4 rounded-lg font-bold text-lg">
             Free Quotes…
           </Link>
         </div>


### PR DESCRIPTION
Closes #7 — All 5 minimal metal structure detail pages now have full content:

- Hero with CTAs
- Use cases grid (4 cards)
- Specs & features list
- Contact CTA

Pages updated: regular-style-metal-carports, boxed-eave-style-metal-carport, vertical-roof-style-metal-carport, pole-truss-stand-roof-kit, pole-truss-enclosed-kits